### PR TITLE
Allow a metric expression and treat missing data override to be used in alarm metric definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module "aws-alb-alarms" {
 | actions_ok                | A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution.   | `list`   | `[]`    |    no    |
 | evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`   |    no    |
 | load_balancer_id          | ALB ID                                                                                                   | `string` | n/a     |   yes    |
-| metric_expression         | A Cloudwatch metric expression to use for a math expression                                              | `string` | `""`   |    no    |
+| metric_expression         | A Cloudwatch metric expression to use for a math expression                                              | `string` | `""`    |    no    |
 | prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`    |    no    |
 | response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`  |    no    |
 | unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module "aws-alb-alarms" {
 | actions_ok                | A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution.   | `list`   | `[]`    |    no    |
 | evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`   |    no    |
 | load_balancer_id          | ALB ID                                                                                                   | `string` | n/a     |   yes    |
+| metric_expression         | A Cloudwatch metric expression to use for a math expression                                              | `string` | `""`   |    no    |
 | prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`    |    no    |
 | response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`  |    no    |
 | unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |

--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ module "aws-alb-alarms" {
 
 ## Variables
 
-| Name                      | Description                                                                                              | Type     | Default | Required |
-| ------------------------- | -------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
-| actions_alarm             | A list of actions to take when alarms are triggered. Will likely be an SNS topic for event distribution. | `list`   | `[]`    |    no    |
-| actions_ok                | A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution.   | `list`   | `[]`    |    no    |
-| evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`   |    no    |
-| load_balancer_id          | ALB ID                                                                                                   | `string` | n/a     |   yes    |
-| metric_expression         | A Cloudwatch metric expression to use for a math expression                                              | `string` | `""`    |    no    |
-| prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`    |    no    |
-| response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`  |    no    |
-| unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |
-| healthy_hosts_threshold   | The number of healthy hosts.                                                                             | `string` | `"0"`   |    no    |
-| statistic_period          | The number of seconds that make each statistic period.                                                   | `string` | `"60"`  |    no    |
-| target_group_id           | Target Group ID                                                                                          | `string` | n/a     |   yes    |
+| Name                      | Description                                                                                              | Type     | Default   | Required |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- | -------- | --------- | :------: |
+| actions_alarm             | A list of actions to take when alarms are triggered. Will likely be an SNS topic for event distribution. | `list`   | `[]`      |    no    |
+| actions_ok                | A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution.   | `list`   | `[]`      |    no    |
+| evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`     |    no    |
+| load_balancer_id          | ALB ID                                                                                                   | `string` | n/a       |   yes    |
+| metric_expression         | A Cloudwatch metric expression to use for a math expression                                              | `string` | `""`      |    no    |
+| prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`      |    no    |
+| response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`    |    no    |
+| unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`     |    no    |
+| healthy_hosts_threshold   | The number of healthy hosts.                                                                             | `string` | `"0"`     |    no    |
+| statistic_period          | The number of seconds that make each statistic period.                                                   | `string` | `"60"`    |    no    |
+| target_group_id           | Target Group ID                                                                                          | `string` | n/a       |   yes    |
+| treat_missing_data        | How to treat missing Cloudwatch metric data                                                              | `string` | `missing` |    no    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
   alarm_description   = "Average API 5XX load balancer error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
+  treat_missing_data  = "ignore"
 
   metric_query {
     id          = "e1"
@@ -72,6 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
   alarm_description   = format("Average API response time is greater than %s", var.response_time_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
+  treat_missing_data  = "ignore"
 
   metric_query {
     id          = "e1"
@@ -105,6 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
   alarm_description   = format("Unhealthy host count is greater than %s", var.unhealthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
+  treat_missing_data  = "ignore"
 
   metric_query {
     id          = "e1"
@@ -139,6 +142,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
   alarm_description   = format("Healthy host count is less than or equal to %s", var.healthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
+  treat_missing_data  = "ignore"
 
   metric_query {
     id          = "e1"

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   alarm_description   = "Average API 5XX target group error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
+  treat_missing_data  = "ignore"
 
   metric_query {
     id          = "e1"

--- a/main.tf
+++ b/main.tf
@@ -9,20 +9,19 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
 
   metric_query {
     id          = "e1"
-    expression  = "FILL(m1, LINEAR)"
-    label       = "Linear filled metric"
-    return_data = (var.linear_fill_missing_data ? "true" : "false")
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
   metric_query {
     id = "m1"
-    return_data = (var.linear_fill_missing_data ? "false" : "true")
+    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
 
     metric {
       metric_name         = "HTTPCode_Target_5XX_Count"
       namespace           = "AWS/ApplicationELB"
       period              = var.statistic_period
-      statistic           = "Sum"
+      stat                = "Sum"
 
       dimensions = {
         "TargetGroup"  = var.target_group_id
@@ -43,20 +42,19 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
 
   metric_query {
     id          = "e1"
-    expression  = "FILL(m1, LINEAR)"
-    label       = "Linear filled metric"
-    return_data = (var.linear_fill_missing_data ? "true" : "false")
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
   metric_query {
     id = "m1"
-    return_data = (var.linear_fill_missing_data ? "false" : "true")
+    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
 
     metric {
       metric_name         = "HTTPCode_ELB_5XX_Count"
       namespace           = "AWS/ApplicationELB"
       period              = var.statistic_period
-      statistic           = "Sum"
+      stat                = "Sum"
 
       dimensions = {
         "LoadBalancer" = var.load_balancer_id
@@ -76,20 +74,19 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
 
   metric_query {
     id          = "e1"
-    expression  = "FILL(m1, LINEAR)"
-    label       = "Linear filled metric"
-    return_data = (var.linear_fill_missing_data ? "true" : "false")
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
   metric_query {
     id = "m1"
-    return_data = (var.linear_fill_missing_data ? "false" : "true")
+    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
 
     metric {
       metric_name         = "TargetResponseTime"
       namespace           = "AWS/ApplicationELB"
       period              = var.statistic_period
-      statistic           = "Average"
+      stat                = "Average"
 
       dimensions = {
         "TargetGroup"  = var.target_group_id
@@ -110,20 +107,19 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
 
   metric_query {
     id          = "e1"
-    expression  = "FILL(m1, LINEAR)"
-    label       = "Linear filled metric"
-    return_data = (var.linear_fill_missing_data ? "true" : "false")
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
   metric_query {
     id = "m1"
-    return_data = (var.linear_fill_missing_data ? "false" : "true")
+    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
 
     metric {
       metric_name         = "UnHealthyHostCount"
       namespace           = "AWS/ApplicationELB"
       period              = var.statistic_period
-      statistic           = "Minimum"
+      stat                = "Minimum"
 
       dimensions = {
         "TargetGroup"  = var.target_group_id
@@ -145,20 +141,19 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
 
   metric_query {
     id          = "e1"
-    expression  = "FILL(m1, LINEAR)"
-    label       = "Linear filled metric"
-    return_data = (var.linear_fill_missing_data ? "true" : "false")
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
   metric_query {
     id = "m1"
-    return_data = (var.linear_fill_missing_data ? "false" : "true")
+    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
 
     metric {
       metric_name         = "HealthyHostCount"
       namespace           = "AWS/ApplicationELB"
       period              = var.statistic_period
-      statistic           = "Minimum"
+      stat                = "Minimum"
 
       dimensions = {
         "TargetGroup"  = var.target_group_id

--- a/main.tf
+++ b/main.tf
@@ -2,18 +2,33 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   alarm_name          = "${var.prefix}alb-tg-${var.target_group_id}-high5XXCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = var.statistic_period
-  statistic           = "Sum"
   threshold           = "0"
   alarm_description   = "Average API 5XX target group error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
 
-  dimensions = {
-    "TargetGroup"  = var.target_group_id
-    "LoadBalancer" = var.load_balancer_id
+  metric_query {
+    id          = "e1"
+    expression  = "FILL(m1, LINEAR)"
+    label       = "Linear filled metric"
+    return_data = (var.linear_fill_missing_data ? "true" : "false")
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = (var.linear_fill_missing_data ? "false" : "true")
+
+    metric {
+      metric_name         = "HTTPCode_Target_5XX_Count"
+      namespace           = "AWS/ApplicationELB"
+      period              = var.statistic_period
+      statistic           = "Sum"
+
+      dimensions = {
+        "TargetGroup"  = var.target_group_id
+        "LoadBalancer" = var.load_balancer_id
+      }
+    }
   }
 }
 
@@ -21,17 +36,32 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
   alarm_name          = "${var.prefix}alb-${var.load_balancer_id}-high5XXCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
-  metric_name         = "HTTPCode_ELB_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = var.statistic_period
-  statistic           = "Sum"
   threshold           = "0"
   alarm_description   = "Average API 5XX load balancer error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
 
-  dimensions = {
-    "LoadBalancer" = var.load_balancer_id
+  metric_query {
+    id          = "e1"
+    expression  = "FILL(m1, LINEAR)"
+    label       = "Linear filled metric"
+    return_data = (var.linear_fill_missing_data ? "true" : "false")
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = (var.linear_fill_missing_data ? "false" : "true")
+
+    metric {
+      metric_name         = "HTTPCode_ELB_5XX_Count"
+      namespace           = "AWS/ApplicationELB"
+      period              = var.statistic_period
+      statistic           = "Sum"
+
+      dimensions = {
+        "LoadBalancer" = var.load_balancer_id
+      }
+    }
   }
 }
 
@@ -39,18 +69,33 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
   alarm_name          = "${var.prefix}alb-tg-${var.target_group_id}-highResponseTime"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
-  metric_name         = "TargetResponseTime"
-  namespace           = "AWS/ApplicationELB"
-  period              = var.statistic_period
-  statistic           = "Average"
   threshold           = var.response_time_threshold
   alarm_description   = format("Average API response time is greater than %s", var.response_time_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
 
-  dimensions = {
-    "TargetGroup"  = var.target_group_id
-    "LoadBalancer" = var.load_balancer_id
+  metric_query {
+    id          = "e1"
+    expression  = "FILL(m1, LINEAR)"
+    label       = "Linear filled metric"
+    return_data = (var.linear_fill_missing_data ? "true" : "false")
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = (var.linear_fill_missing_data ? "false" : "true")
+
+    metric {
+      metric_name         = "TargetResponseTime"
+      namespace           = "AWS/ApplicationELB"
+      period              = var.statistic_period
+      statistic           = "Average"
+
+      dimensions = {
+        "TargetGroup"  = var.target_group_id
+        "LoadBalancer" = var.load_balancer_id
+      }
+    }
   }
 }
 
@@ -58,18 +103,33 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
   alarm_name          = "${var.prefix}alb-tg-${var.target_group_id}-unhealthy-hosts"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
-  metric_name         = "UnHealthyHostCount"
-  namespace           = "AWS/ApplicationELB"
-  period              = var.statistic_period
-  statistic           = "Minimum"
   threshold           = var.unhealthy_hosts_threshold
   alarm_description   = format("Unhealthy host count is greater than %s", var.unhealthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
 
-  dimensions = {
-    "TargetGroup"  = var.target_group_id
-    "LoadBalancer" = var.load_balancer_id
+  metric_query {
+    id          = "e1"
+    expression  = "FILL(m1, LINEAR)"
+    label       = "Linear filled metric"
+    return_data = (var.linear_fill_missing_data ? "true" : "false")
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = (var.linear_fill_missing_data ? "false" : "true")
+
+    metric {
+      metric_name         = "UnHealthyHostCount"
+      namespace           = "AWS/ApplicationELB"
+      period              = var.statistic_period
+      statistic           = "Minimum"
+
+      dimensions = {
+        "TargetGroup"  = var.target_group_id
+        "LoadBalancer" = var.load_balancer_id
+      }
+    }
   }
 }
 
@@ -77,17 +137,33 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
   alarm_name          = "${var.prefix}alb-tg-${var.target_group_id}-healthy-hosts"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = var.evaluation_period
-  metric_name         = "HealthyHostCount"
-  namespace           = "AWS/ApplicationELB"
-  period              = var.statistic_period
-  statistic           = "Minimum"
+
   threshold           = var.healthy_hosts_threshold
   alarm_description   = format("Healthy host count is less than or equal to %s", var.healthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
 
-  dimensions = {
-    "TargetGroup"  = var.target_group_id
-    "LoadBalancer" = var.load_balancer_id
+  metric_query {
+    id          = "e1"
+    expression  = "FILL(m1, LINEAR)"
+    label       = "Linear filled metric"
+    return_data = (var.linear_fill_missing_data ? "true" : "false")
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = (var.linear_fill_missing_data ? "false" : "true")
+
+    metric {
+      metric_name         = "HealthyHostCount"
+      namespace           = "AWS/ApplicationELB"
+      period              = var.statistic_period
+      statistic           = "Minimum"
+
+      dimensions = {
+        "TargetGroup"  = var.target_group_id
+        "LoadBalancer" = var.load_balancer_id
+      }
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
 
   metric_query {
     id          = "e1"
-    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
     return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
 
   metric_query {
     id          = "e1"
-    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
     return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
 
   metric_query {
     id          = "e1"
-    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
     return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
 
   metric_query {
     id          = "e1"
-    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
     return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 
@@ -141,7 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
 
   metric_query {
     id          = "e1"
-    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "FILL(m1, LINEAR)"
+    expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
     return_data = (length(var.metric_expression) > 0 ? "true" : "false")
   }
 

--- a/main.tf
+++ b/main.tf
@@ -6,17 +6,17 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   alarm_description   = "Average API 5XX target group error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
-  treat_missing_data  = "ignore"
+  treat_missing_data  = var.treat_missing_data
 
   metric_query {
     id          = "e1"
     expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
-    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
+    return_data = length(var.metric_expression) > 0 ? "true" : "false"
   }
 
   metric_query {
     id = "m1"
-    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
+    return_data = length(var.metric_expression) > 0 ? "false" : "true"
 
     metric {
       metric_name         = "HTTPCode_Target_5XX_Count"
@@ -40,17 +40,17 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
   alarm_description   = "Average API 5XX load balancer error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
-  treat_missing_data  = "ignore"
+  treat_missing_data  = var.treat_missing_data
 
   metric_query {
     id          = "e1"
     expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
-    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
+    return_data = length(var.metric_expression) > 0 ? "true" : "false"
   }
 
   metric_query {
     id = "m1"
-    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
+    return_data = length(var.metric_expression) > 0 ? "false" : "true"
 
     metric {
       metric_name         = "HTTPCode_ELB_5XX_Count"
@@ -73,17 +73,17 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
   alarm_description   = format("Average API response time is greater than %s", var.response_time_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
-  treat_missing_data  = "ignore"
+  treat_missing_data  = var.treat_missing_data
 
   metric_query {
     id          = "e1"
     expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
-    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
+    return_data = length(var.metric_expression) > 0 ? "true" : "false"
   }
 
   metric_query {
     id = "m1"
-    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
+    return_data = length(var.metric_expression) > 0 ? "false" : "true"
 
     metric {
       metric_name         = "TargetResponseTime"
@@ -107,17 +107,17 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts" {
   alarm_description   = format("Unhealthy host count is greater than %s", var.unhealthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
-  treat_missing_data  = "ignore"
+  treat_missing_data  = var.treat_missing_data
 
   metric_query {
     id          = "e1"
     expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
-    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
+    return_data = length(var.metric_expression) > 0 ? "true" : "false"
   }
 
   metric_query {
     id = "m1"
-    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
+    return_data = length(var.metric_expression) > 0 ? "false" : "true"
 
     metric {
       metric_name         = "UnHealthyHostCount"
@@ -142,17 +142,17 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
   alarm_description   = format("Healthy host count is less than or equal to %s", var.healthy_hosts_threshold)
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
-  treat_missing_data  = "ignore"
+  treat_missing_data  = var.treat_missing_data
 
   metric_query {
     id          = "e1"
     expression  = length(var.metric_expression) > 0 ? var.metric_expression : "m1"
-    return_data = (length(var.metric_expression) > 0 ? "true" : "false")
+    return_data = length(var.metric_expression) > 0 ? "true" : "false"
   }
 
   metric_query {
     id = "m1"
-    return_data = (length(var.metric_expression) > 0 ? "false" : "true")
+    return_data = length(var.metric_expression) > 0 ? "false" : "true"
 
     metric {
       metric_name         = "HealthyHostCount"

--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,8 @@ variable "actions_ok" {
   description = "A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution."
 }
 
-variable "linear_fill_missing_data" {
-  type        = bool
-  default     = false
-  description = "Linear fill missing data."
+variable "metric_expression" {
+  description = "A Cloudwatch metric expression to use for a math expression"
+  type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "actions_ok" {
   description = "A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution."
 }
 
+variable "treat_missing_data" {
+  description = "How to treat missing Cloudwatch metric data"
+  type        = string
+  default     = "missing"
+}
+
 variable "metric_expression" {
   description = "A Cloudwatch metric expression to use for a math expression"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,9 @@ variable "actions_ok" {
   default     = []
   description = "A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution."
 }
+
+variable "linear_fill_missing_data" {
+  type        = bool
+  default     = false
+  description = "Linear fill missing data."
+}


### PR DESCRIPTION
Adds the ability to use a metric expression and how to treat missing data in AWS to prevent raising INSUFFICIENT_DATA alarms due to sparse data Cloudwatch in metrics.

Not passing `metric_expression` or `treat_missing_data` will keep existing behavior. Setting `treat_missing_data` will override the default behavior of treating missing data as `missing`. Passing in `metric_expression` with an expression such as `FILL(m1, REPEAT)` perform a fill function as documented on AWS' metric math page:

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html